### PR TITLE
Removed outdated SDK import from java Dockerfile

### DIFF
--- a/subtraction-services/java/rest/Dockerfile
+++ b/subtraction-services/java/rest/Dockerfile
@@ -8,7 +8,6 @@ COPY settings.gradle ./
 COPY gradle/* ./gradle/wrapper
 COPY gradlew ./
 COPY src/main/java/architect_subtraction_service/* ./src/main/java/architect_subtraction_service/
-COPY build/libs/* ./build/libs/
 
 RUN ./gradlew installDist
 


### PR DESCRIPTION
Now that we're importing from maven, this line breaks the docker build